### PR TITLE
add ability to set codepage explicitly for BIFF5

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -440,6 +440,14 @@ class Xls extends BaseReader
     }
 
     /**
+     * @param string $codepage
+     */
+    public function setCodepage($codepage)
+    {
+        $this->codepage = $codepage;
+    }
+
+    /**
      * Reads names of the worksheets from a file, without parsing the whole file to a PhpSpreadsheet object.
      *
      * @param string $pFilename
@@ -646,7 +654,7 @@ class Xls extends BaseReader
 
         // initialize
         $this->pos = 0;
-        $this->codepage = 'CP1252';
+        $this->codepage = $this->codepage == null ? 'CP1252' : $this->codepage;
         $this->formats = [];
         $this->objFonts = [];
         $this->palette = [];


### PR DESCRIPTION
If BIFF5 excel 95 file doesn't have codepage record, the default codepage CP1252 is used and can't be change.
That causes to problems with decoding cyrillic text.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
If excel 95 file doesn't contain codepage record, cyrillic text can't be decoded well, because CP1252 charset is used by default and it can't be changed explicitly. Setting codepage to CP1251 does the job.
